### PR TITLE
feat: add data types for text type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+export type NodeType = "BOX" | "TEXT"
+
 export interface NodeRect {
   x: number;
   y: number;
@@ -9,20 +11,42 @@ export interface BoxStyles {
   backgroundColor: string;
   opacity: number;
   zIndex: number;
+
+  borderRadius: string;
+  borderColor: string;
+  borderWidth: string;
+}
+
+// For CanvasRenderingContext2D
+export interface TextStyles {
+  font: string;
+  color: string;
+  textAlign: CanvasTextAlign;
+  textBaseline: CanvasTextBaseline;
+  direction: CanvasDirection;
+  lineHeight: number;    // px
+  letterSpacing: number; // px
 }
 
 export interface SceneNode {
-  type: "BOX";
+  id: string;
+  type: NodeType;
   element: HTMLElement;
+  
   rect: NodeRect;
   styles: BoxStyles;
+
+  textContent?: string;
+  textStyles?: TextStyles;
+
   dirtyMask: number;
   children: SceneNode[];
 }
 
-//Bitmask
+//Bitmask Flags
 export const DIRTY_NONE = 0;
-export const DIRTY_RECT = 1 << 0; // 1: x, y, width, height
-export const DIRTY_STYLE = 1 << 1; // 2: style
-export const DIRTY_ZINDEX = 1 << 2; // 4: zIndex
-export const DIRTY_STRUCTURE = 1 << 3; // 8: childNode add / delete
+export const DIRTY_RECT = 1 << 0; // 1: x, y, width, height (00000001)
+export const DIRTY_STYLE = 1 << 1; // 2: style (00000010)
+export const DIRTY_ZINDEX = 1 << 2; // 4: zIndex (00000100)
+export const DIRTY_STRUCTURE = 1 << 3; // 8: childNode add / delete (00001000)
+export const DIRTY_CONTENT = 1 << 4;   // 16: text content changed (00010000)


### PR DESCRIPTION
add `NodeType`(type)

add `TestStyles`(interface)

add `id`, `textContent`, `textStyles` in `SceneNode`(interface)
fix `type` in `SceneNode`(interface)

add `DIRTY_CONTENT` Bitmask flag